### PR TITLE
New param of `id` since fluentd v0.12

### DIFF
--- a/syntax/fluentd.vim
+++ b/syntax/fluentd.vim
@@ -21,7 +21,7 @@ syn match fluentdComment +#.*+
 syn keyword pluginDirective source match store server
 syn keyword includeDirective include
 
-syn keyword Command type path time_format port
+syn keyword Command id type path time_format port
 
 syn keyword inputPluginCommand pos_file
 syn keyword inputPluginCommandHttp bind body_size_limit keepalive_timeout


### PR DESCRIPTION
see also:
  http://www.fluentd.org/blog/fluentd-v0.12-is-released
  http://docs.fluentd.org/articles/config-file#common-plugin-parameter
